### PR TITLE
build: replace bun build with tsc-only transpilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun build index.ts --outdir dist && tsc -p tsconfig.build.json"
+    "build": "tsc -p tsconfig.build.json"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,10 +2,11 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",
+    "rootDir": ".",
     "rewriteRelativeImportExtensions": true
-  }
+  },
+  "include": ["index.ts"]
 }


### PR DESCRIPTION
## Summary
- `bun build --no-bundle --outdir` is broken on the current Bun release ([oven-sh/bun#5206](https://github.com/oven-sh/bun/issues/5206), [#10370](https://github.com/oven-sh/bun/issues/10370)).
- Plain `tsc` achieves the same result without depending on Bun's bundler at all: transpiles `index.ts` into `dist/`, rewriting relative import extensions as needed (`rewriteRelativeImportExtensions` was already set).

## Test plan
- [x] `bun run build` succeeds, produces `dist/index.js` + `dist/index.d.ts`
- [x] `bunx tsc --noEmit` passes
- [x] `bunx oxlint index.ts` passes